### PR TITLE
Remove support for tvOS in Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,6 @@ let package = Package(
     platforms: [
         .iOS(.v14),
         .macOS(.v11),
-        .tvOS(.v14),
         .visionOS(.v1),
         .watchOS(.v9),
     ],


### PR DESCRIPTION
From what I can tell there's no way to present a web view on tvOS, but the package includes it as a supported platform even though there are no `View`s available to use.